### PR TITLE
MP-1384 Removed insurance from shipment schema

### DIFF
--- a/specification/definitions/Shipment.json
+++ b/specification/definitions/Shipment.json
@@ -98,9 +98,6 @@
           "type": "string",
           "example": "order #8008135"
         },
-        "insurance": {
-          "$ref": "../includes/price.json"
-        },
         "barcode": {
           "readOnly": true,
           "type": "string",


### PR DESCRIPTION
**Changes**
- Removed insurance attribute from shipment schema

**Related issues**
- https://myparcelcombv.atlassian.net/browse/MP-1384 (subtask)
- https://myparcelcombv.atlassian.net/browse/MP-1320 (story)