### PR TITLE
:sparkles: Added track_trace meta to post shipment endpoint.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "myparcelcom-carrier-specification",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Specification of the carrier API required by MyParcel.com",
   "repository": {
     "type": "git",

--- a/specification/info.json
+++ b/specification/info.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.0",
+  "version": "0.5.0",
   "title": "MyParcel.com Carrier API Specification",
   "description": "**Introduction**This is the carrier API reference for MyParcel.com implementing the [Swagger specification](https://swagger.io/specification) according to [JSON API](http://jsonapi.org) conventions.<br>For more information visit our [API documentation](https://docs.myparcel.com).**Units**Some attributes in the API have values in one of the following units:<ul><li>Currency: cents where applicable (eg. EUR, GBP, USD), otherwise the basic unit (eg. JPY, NOK)</li><li>Distances: meters</li><li>Dimensions: millimeters</li><li>Volumes: liters (dm3)</li><li>Weights: grams</li></ul>",
   "termsOfService": "https://www.myparcel.com/terms",

--- a/specification/paths/Shipments.json
+++ b/specification/paths/Shipments.json
@@ -20,6 +20,24 @@
           "properties": {
             "data": {
               "$ref": "#/definitions/Shipment"
+            },
+            "meta": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "track_trace": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean",
+                      "description": "Indicates whether or not the carrier should send track and trace emails for this shipment.",
+                      "example": false,
+                      "default": true
+                    }
+                  }
+                }
+              }
             }
           }
         }


### PR DESCRIPTION
**Changes**
- Added `meta` with `track_trace` to the POST shipment endpoint.

**Related Issues**
- https://myparcelcombv.atlassian.net/browse/MP-1293