### PR TITLE
Bugfix/status id should be required

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,7 @@
 {
   "name": "myparcelcom-carrier-specification",
-  "version": "0.8.2",
-  "lockfileVersion": 1,
   "requires": true,
+  "lockfileVersion": 1,
   "dependencies": {
     "accepts": {
       "version": "1.3.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "myparcelcom-carrier-specification",
-  "version": "0.8.2",
   "description": "Specification of the carrier API required by MyParcel.com",
   "repository": {
     "type": "git",

--- a/specification/definitions/Status.json
+++ b/specification/definitions/Status.json
@@ -1,6 +1,7 @@
 {
   "type": "object",
   "required": [
+    "id",
     "type",
     "attributes"
   ],

--- a/specification/info.json
+++ b/specification/info.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.8.2",
+  "version": "0.9.0",
   "title": "MyParcel.com Carrier API Specification",
   "description": "**Introduction**This is the carrier API reference for MyParcel.com implementing the [Swagger specification](https://swagger.io/specification) according to [JSON API](http://jsonapi.org) conventions.<br>For more information visit our [API documentation](https://docs.myparcel.com).**Units**Some attributes in the API have values in one of the following units:<ul><li>Currency: cents where applicable (eg. EUR, GBP, USD), otherwise the basic unit (eg. JPY, NOK)</li><li>Distances: meters</li><li>Dimensions: millimeters</li><li>Volumes: liters (dm3)</li><li>Weights: grams</li></ul>",
   "termsOfService": "https://www.myparcel.com/terms",


### PR DESCRIPTION
`status.id` should have been required. Now it is.