### PR TITLE
🐛 This will make requests to /carrier-specification to work

### DIFF
--- a/docker/build/default.conf
+++ b/docker/build/default.conf
@@ -1,6 +1,7 @@
 server {
-    listen       80;
-    server_name  localhost;
+    absolute_redirect   off;
+    listen              80;
+    server_name         localhost;
 
     #charset koi8-r;
     #access_log  /var/log/nginx/host.access.log  main;


### PR DESCRIPTION
I noticed that requests to https://docs.develop.myparcel.com/carrier-specification were hanging. This will fix it.