### PR TITLE
🐛 Fix multi-colli endpoint name

### DIFF
--- a/specification/definitions/TaxIdentificationNumber.json
+++ b/specification/definitions/TaxIdentificationNumber.json
@@ -16,7 +16,10 @@
       "description": "Eori XI number"
     },
     "description": {
-      "type": ["string", "null"],
+      "type": [
+        "string",
+        "null"
+      ],
       "example": "Eori XI number for Northern Ireland"
     },
     "type": {

--- a/specification/paths.json
+++ b/specification/paths.json
@@ -1,5 +1,5 @@
 {
-  "multi-colli-shipment": {
+  "/multi-colli-shipments": {
     "$ref": "./paths/MultiColliShipments.json"
   },
   "/pickup-dropoff-locations/{country_code}/{postal_code}": {


### PR DESCRIPTION
The endpoint name needs to be plural and start with a `/` to create a proper link.