### PR TITLE
♻️ Post master shipment with colli shipments

### DIFF
--- a/specification/paths/MultiColliShipments.json
+++ b/specification/paths/MultiColliShipments.json
@@ -19,9 +19,17 @@
           "additionalProperties": false,
           "properties": {
             "data": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/Shipment"
+              "type": "object",
+              "properties": {
+                "shipment": {
+                  "$ref": "#/definitions/Shipment"
+                },
+                "colli": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Shipment"
+                  }
+                }
               }
             },
             "meta": {
@@ -37,12 +45,6 @@
                       "default": true
                     }
                   }
-                },
-                "label_mime_type": {
-                  "type": "string",
-                  "description": "Deprecated, use `meta.label.mime_type` instead. The requested mime-type for this shipment's label.",
-                  "example": "application/pdf",
-                  "deprecated": true
                 },
                 "label": {
                   "type": "object",
@@ -66,13 +68,6 @@
                       "default": false
                     }
                   }
-                },
-                "print_sku_on_label": {
-                  "type": "boolean",
-                  "description": "Deprecated, use `meta.label.print_sku_on_label` instead. Indicates whether or not to display SKU information table on the label.",
-                  "example": true,
-                  "default": false,
-                  "deprecated": true
                 }
               }
             }
@@ -91,9 +86,17 @@
           "additionalProperties": false,
           "properties": {
             "data": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/Shipment"
+              "type": "object",
+              "properties": {
+                "shipment": {
+                  "$ref": "#/definitions/Shipment"
+                },
+                "colli": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Shipment"
+                  }
+                }
               }
             }
           }

--- a/specification/paths/MultiColliShipments.json
+++ b/specification/paths/MultiColliShipments.json
@@ -9,7 +9,7 @@
       {
         "in": "body",
         "name": "Multi-colli shipment",
-        "description": "The multi-colli shipment to be created.",
+        "description": "The virtual master shipment and colli shipments to be created as one multi-colli shipment.",
         "required": true,
         "schema": {
           "type": "object",
@@ -21,7 +21,7 @@
             "data": {
               "type": "object",
               "properties": {
-                "shipment": {
+                "master": {
                   "$ref": "#/definitions/Shipment"
                 },
                 "colli": {
@@ -88,7 +88,7 @@
             "data": {
               "type": "object",
               "properties": {
-                "shipment": {
+                "master": {
                   "$ref": "#/definitions/Shipment"
                 },
                 "colli": {


### PR DESCRIPTION
Related to https://myparcelcombv.atlassian.net/browse/MP-4048

PostNL B2C generates a `MainBarcode` and it returns a new barcode for every collo.
The current carrier-specification does not support a master barcode to be passed back.

This PR sends the master shipment back and forth (and removes the deprecated meta from the multi-colli endpoint).