### PR TITLE
🐕‍🦺 MP-4388 Added dynamic service rates to carrier-spec

### DIFF
--- a/specification/definitions.json
+++ b/specification/definitions.json
@@ -1,4 +1,7 @@
 {
+  "BaseShipment": {
+    "$ref": "./definitions/BaseShipment.json"
+  },
   "CountryCode": {
     "$ref": "./definitions/CountryCode.json"
   },

--- a/specification/definitions.json
+++ b/specification/definitions.json
@@ -8,6 +8,9 @@
   "PickupDropoffLocation": {
     "$ref": "./definitions/PickupDropoffLocation.json"
   },
+  "ServiceRate": {
+    "$ref": "./definitions/ServiceRate.json"
+  },
   "Shipment": {
     "$ref": "./definitions/Shipment.json"
   },

--- a/specification/definitions/BaseShipment.json
+++ b/specification/definitions/BaseShipment.json
@@ -1,0 +1,351 @@
+{
+  "type": "object",
+  "required": [
+    "type",
+    "attributes"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "type": {
+      "$ref": "../types/Shipment.json"
+    },
+    "id": {
+      "readOnly": true,
+      "type": "string",
+      "example": "ec234f21-f350-405f-bf02-1c45d1c792e7",
+      "description": "Shipment identifier used by the carrier."
+    },
+    "attributes": {
+      "type": "object",
+      "required": [
+        "recipient_address",
+        "return_address",
+        "sender_address",
+        "service",
+        "physical_properties"
+      ],
+      "properties": {
+        "recipient_address": {
+          "type": "object",
+          "required": [
+            "street_1",
+            "city",
+            "country_code",
+            "first_name",
+            "last_name"
+          ],
+          "properties": {
+            "$ref": "../properties/Address.json"
+          }
+        },
+        "recipient_tax_identification_numbers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/TaxIdentificationNumber"
+          }
+        },
+        "recipient_tax_number": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Use `recipient_tax_identification_numbers` instead.",
+          "deprecated": true
+        },
+        "return_address": {
+          "type": "object",
+          "required": [
+            "street_1",
+            "city",
+            "country_code"
+          ],
+          "properties": {
+            "$ref": "../properties/Address.json"
+          }
+        },
+        "sender_address": {
+          "type": "object",
+          "required": [
+            "street_1",
+            "city",
+            "country_code"
+          ],
+          "properties": {
+            "$ref": "../properties/Address.json"
+          }
+        },
+        "sender_tax_identification_numbers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/TaxIdentificationNumber"
+          }
+        },
+        "sender_tax_number": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Use `sender_tax_identification_numbers` instead.",
+          "deprecated": true
+        },
+        "tax_identification_numbers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/TaxIdentificationNumber"
+          },
+          "description": "Use `sender_tax_identification_numbers` instead.",
+          "deprecated": true
+        },
+        "pickup_location": {
+          "type": "object",
+          "required": [
+            "code",
+            "address"
+          ],
+          "properties": {
+            "code": {
+              "type": "string",
+              "example": "123456"
+            },
+            "address": {
+              "type": "object",
+              "required": [
+                "street_1",
+                "city",
+                "country_code"
+              ],
+              "properties": {
+                "$ref": "../properties/Address.json"
+              }
+            }
+          }
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "example": "order #8008135"
+        },
+        "barcode": {
+          "readOnly": true,
+          "type": "string",
+          "example": "3SABCD0123456789"
+        },
+        "tracking_code": {
+          "readOnly": true,
+          "type": "string",
+          "example": "ASD2KUIAF235"
+        },
+        "tracking_url": {
+          "readOnly": true,
+          "type": "string",
+          "example": "https://tracker.carrier.com/ASD2KUIAF235"
+        },
+        "service": {
+          "type": "object",
+          "properties": {
+            "code": {
+              "type": "string",
+              "example": "service-a01"
+            },
+            "name": {
+              "type": "string",
+              "example": "Parcel to Parcelshop"
+            }
+          }
+        },
+        "options": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "code"
+            ],
+            "properties": {
+              "code": {
+                "type": "string",
+                "example": "delivery-day:sunday"
+              },
+              "name": {
+                "type": "string",
+                "example": "Sunday Delivery"
+              },
+              "values": {
+                "type": "object",
+                "example": {
+                  "pin": "1234"
+                }
+              }
+            }
+          }
+        },
+        "total_value": {
+          "$ref": "../includes/price.json"
+        },
+        "physical_properties": {
+          "$ref": "../includes/physical-properties.json"
+        },
+        "items": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "description",
+              "quantity"
+            ],
+            "properties": {
+              "sku": {
+                "type": "string",
+                "minLength": 1,
+                "example": "123456789"
+              },
+              "description": {
+                "type": "string",
+                "minLength": 1,
+                "example": "OnePlus X"
+              },
+              "image_url": {
+                "type": "string",
+                "example": "https://myparcel.com/product.png",
+                "description": "A link to an image of the item."
+              },
+              "item_value": {
+                "$ref": "../includes/price.json"
+              },
+              "item_weight": {
+                "type": "number",
+                "example": 1000,
+                "description": "Weight of a single item within item resource. Should be multiplied by quantity to get total weight."
+              },
+              "quantity": {
+                "type": "number",
+                "example": 2
+              },
+              "hs_code": {
+                "type": "string",
+                "pattern": "^[0-9.]+$",
+                "example": "8517.12.00",
+                "description": "Harmonized System code used by customs."
+              },
+              "origin_country_code": {
+                "$ref": "#/definitions/CountryCode"
+              },
+              "tax": {
+                "$ref": "../includes/price-readonly.json"
+              },
+              "duty": {
+                "$ref": "../includes/price-readonly.json"
+              },
+              "vat_percentage": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "min": 0,
+                "max": 100,
+                "example": 19,
+                "description": "The VAT rate applied to the `item_value` amount."
+              }
+            }
+          }
+        },
+        "customs": {
+          "type": "object",
+          "properties": {
+            "content_type": {
+              "type": "string",
+              "enum": [
+                "merchandise",
+                "sample_merchandise",
+                "returned_merchandise",
+                "documents",
+                "gifts"
+              ],
+              "example": "merchandise"
+            },
+            "invoice_number": {
+              "type": "string",
+              "example": "9000"
+            },
+            "non_delivery": {
+              "type": "string",
+              "enum": [
+                "return",
+                "abandon"
+              ],
+              "example": "return",
+              "description": "Action when the parcel cannot be delivered."
+            },
+            "incoterm": {
+              "type": "string",
+              "enum": [
+                "DAP",
+                "DDP"
+              ],
+              "example": "DAP",
+              "description": "DAP (Delivered At Place) or DDP (Delivered Duty Paid)."
+            },
+            "shipping_value": {
+              "$ref": "../includes/price.json"
+            },
+            "total_tax": {
+              "$ref": "../includes/price-readonly.json"
+            },
+            "total_duty": {
+              "$ref": "../includes/price-readonly.json"
+            }
+          }
+        },
+        "channel": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "example": "MyParcel.com",
+          "description": "Name of the application used to create the shipment."
+        },
+        "files": {
+          "readOnly": true,
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "resource_type",
+              "data"
+            ],
+            "properties": {
+              "resource_type": {
+                "type": "string",
+                "enum": [
+                  "label",
+                  "printcode",
+                  "invoice"
+                ],
+                "example": "label"
+              },
+              "mime_type": {
+                "type": "string",
+                "example": "application/pdf"
+              },
+              "extension": {
+                "type": "string",
+                "example": "pdf"
+              },
+              "data": {
+                "type": "string",
+                "example": "iVBORw0KTaIx+wMm04spN/rQWAAAAABJRU5ErkJggg=="
+              }
+            }
+          }
+        },
+        "collo_number": {
+          "readOnly": true,
+          "type": "number",
+          "example": 1,
+          "description": "A number identifying this collo in a multi-colli shipment."
+        }
+      }
+    }
+  }
+}

--- a/specification/definitions/BaseShipment.json
+++ b/specification/definitions/BaseShipment.json
@@ -21,7 +21,6 @@
         "recipient_address",
         "return_address",
         "sender_address",
-        "service",
         "physical_properties"
       ],
       "properties": {

--- a/specification/definitions/ServiceRate.json
+++ b/specification/definitions/ServiceRate.json
@@ -11,16 +11,8 @@
     "attributes": {
       "type": "object",
       "required": [
-        "code",
-        "weight_min",
-        "weight_max",
-        "length_max",
-        "width_max",
-        "height_max",
-        "volume_max",
         "price",
-        "purchase_price",
-        "fuel_surcharge"
+        "purchase_price"
       ],
       "properties": {
         "code": {

--- a/specification/definitions/ServiceRate.json
+++ b/specification/definitions/ServiceRate.json
@@ -1,0 +1,67 @@
+{
+  "type": "object",
+  "required": [
+    "type"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "type": {
+      "$ref": "../types/ServiceRate.json"
+    },
+    "attributes": {
+      "type": "object",
+      "required": [
+        "code",
+        "weight_min",
+        "weight_max",
+        "length_max",
+        "width_max",
+        "height_max",
+        "volume_max",
+        "price",
+        "purchase_price",
+        "fuel_surcharge"
+      ],
+      "properties": {
+        "code": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 255
+        },
+        "weight_min": {
+          "type": "number",
+          "minimum": 0
+        },
+        "weight_max": {
+          "type": "number",
+          "minimum": 0
+        },
+        "length_max": {
+          "type": "number",
+          "minimum": 0
+        },
+        "width_max": {
+          "type": "number",
+          "minimum": 0
+        },
+        "height_max": {
+          "type": "number",
+          "minimum": 0
+        },
+        "volume_max": {
+          "type": "number",
+          "minimum": 0
+        },
+        "price": {
+          "$ref": "../includes/price.json"
+        },
+        "purchase_price": {
+          "$ref": "../includes/price.json"
+        },
+        "fuel_surcharge": {
+          "$ref": "../includes/price.json"
+        }
+      }
+    }
+  }
+}

--- a/specification/paths.json
+++ b/specification/paths.json
@@ -1,4 +1,7 @@
 {
+  "/get-service-rates": {
+    "$ref": "./paths/ServiceRates.json"
+  },
   "/multi-colli-shipments": {
     "$ref": "./paths/MultiColliShipments.json"
   },

--- a/specification/paths/ServiceRates.json
+++ b/specification/paths/ServiceRates.json
@@ -1,0 +1,53 @@
+{
+  "post": {
+    "tags": [
+      "Service rates"
+    ],
+    "summary": "Get service rates for a shipment",
+    "description": "This endpoint retrieves service rates of the carrier based on the supplied shipment.",
+    "parameters": [
+      {
+        "in": "body",
+        "name": "shipment",
+        "description": "The shipment object to be created.",
+        "required": true,
+        "schema": {
+          "type": "object",
+          "required": [
+            "data"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/Shipment"
+            }
+          }
+        }
+      }
+    ],
+    "responses": {
+      "200": {
+        "description": "Retrieved the service rates.",
+        "content": {
+          "application/vnd.api+json": {
+            "schema": {
+              "type": "object",
+              "required": [
+                "data"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/ServiceRate"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/paths/ServiceRates.json
+++ b/specification/paths/ServiceRates.json
@@ -1,7 +1,7 @@
 {
   "post": {
     "tags": [
-      "Service rates"
+      "ServiceRates"
     ],
     "summary": "Get service rates for a shipment",
     "description": "This endpoint retrieves service rates of the carrier based on the supplied shipment.",
@@ -19,7 +19,7 @@
           "additionalProperties": false,
           "properties": {
             "data": {
-              "$ref": "#/definitions/Shipment"
+              "$ref": "#/definitions/BaseShipment"
             }
           }
         }

--- a/specification/tags.json
+++ b/specification/tags.json
@@ -1,5 +1,9 @@
 [
   {
+    "name": "ServiceRates",
+    "description": ""
+  },
+  {
     "name": "MultiColliShipments",
     "description": ""
   },

--- a/specification/tags.json
+++ b/specification/tags.json
@@ -1,14 +1,14 @@
 [
   {
-    "name": "ServiceRates",
-    "description": ""
-  },
-  {
     "name": "MultiColliShipments",
     "description": ""
   },
   {
     "name": "PickupDropoffLocations",
+    "description": ""
+  },
+  {
+    "name": "ServiceRates",
     "description": ""
   },
   {

--- a/specification/types/ServiceRate.json
+++ b/specification/types/ServiceRate.json
@@ -1,0 +1,5 @@
+{
+  "type": "string",
+  "pattern": "^service-rates$",
+  "example": "service-rates"
+}


### PR DESCRIPTION
# Changes
- Introduced `/get-service-rates`
- Added `ServiceRate` resource

# Note
- Please let me know how to make the service code in the nested service object on the referenced shipment optional. I have no idea how except if I redefine the whole shipment.

## Issue
- https://myparcelcombv.atlassian.net/browse/MP-4388