### PR TITLE
🐞 Making the manifest files optional

### DIFF
--- a/specification/definitions/Manifest.json
+++ b/specification/definitions/Manifest.json
@@ -13,8 +13,7 @@
     "attributes": {
       "type": "object",
       "required": [
-        "name",
-        "files"
+        "name"
       ],
       "properties": {
         "name": {


### PR DESCRIPTION
# Changes
Having the files attribute as required breaks the validation in microservices. Therefore we should have it as optional in the definition because it becomes required later in the response