### PR TITLE
🐞 The shipment ID can have other contents than UUID

### DIFF
--- a/specification/definitions/MinimalShipment.json
+++ b/specification/definitions/MinimalShipment.json
@@ -9,8 +9,6 @@
     },
     "id": {
       "type": "string",
-      "format": "uuid",
-      "pattern": "^[a-f\\d]{8}(-[a-f\\d]{4}){3}-[a-f\\d]{12}$",
       "example": "be7f6752-34e0-49a1-a832-bcc209450ea9"
     }
   }


### PR DESCRIPTION
# Changes
The Shipment ID is not necessarily a UUID. The ID is what the shipments resource returns. The `myparcelcom_shipment_id` is always a uuid, but that is different.