### PR TITLE
Removed openapi 3.0 elements, schema is swagger 2.0

### DIFF
--- a/specification/paths/Manifests.json
+++ b/specification/paths/Manifests.json
@@ -28,21 +28,17 @@
     "responses": {
       "201": {
         "description": "Created the manifest.",
-        "content": {
-          "application/vnd.api+json": {
-            "schema": {
-              "type": "object",
-              "required": [
-                "data"
-              ],
-              "additionalProperties": false,
-              "properties": {
-                "data": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/Manifest"
-                  }
-                }
+        "schema": {
+          "type": "object",
+          "required": [
+            "data"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "data": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Manifest"
               }
             }
           }

--- a/specification/paths/ServiceRates.json
+++ b/specification/paths/ServiceRates.json
@@ -28,21 +28,17 @@
     "responses": {
       "200": {
         "description": "Retrieved the service rates.",
-        "content": {
-          "application/vnd.api+json": {
-            "schema": {
-              "type": "object",
-              "required": [
-                "data"
-              ],
-              "additionalProperties": false,
-              "properties": {
-                "data": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/ServiceRate"
-                  }
-                }
+        "schema": {
+          "type": "object",
+          "required": [
+            "data"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "data": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ServiceRate"
               }
             }
           }


### PR DESCRIPTION
# Changes
The schema used for carrier-specification is still swagger 2.0, not openapi 3.0. Therefore, the "contents" element is not supported. 