### PR TITLE
🔥 Removed collection_date requirement since the attribute is gone

### DIFF
--- a/specification/paths/Collections-collection_id.json
+++ b/specification/paths/Collections-collection_id.json
@@ -81,7 +81,6 @@
                       "required": [
                         "myparcelcom_collection_id",
                         "name",
-                        "collection_date",
                         "collection_time",
                         "address"
                       ],

--- a/specification/paths/Collections.json
+++ b/specification/paths/Collections.json
@@ -35,7 +35,6 @@
                       "required": [
                         "myparcelcom_collection_id",
                         "name",
-                        "collection_date",
                         "collection_time",
                         "address"
                       ]
@@ -76,7 +75,6 @@
                       "required": [
                         "myparcelcom_collection_id",
                         "name",
-                        "collection_date",
                         "collection_time",
                         "address"
                       ]


### PR DESCRIPTION
The `collection_date` attribute has been removed in https://github.com/MyParcelCOM/carrier-specification/pull/179