### PR TITLE
✏️ Rename delivery-day to delivery-window

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: .
       dockerfile: docker/json-bundler/Dockerfile
-    image: myparcelcom/json-bundler:v2-dev
+    image: myparcelcom/json-bundler:v3-dev
     working_dir: /opt/spec
     volumes:
       - .:/opt/spec

--- a/docker/json-bundler/Dockerfile
+++ b/docker/json-bundler/Dockerfile
@@ -1,3 +1,3 @@
-FROM node:14
+FROM node:16
 
 RUN npm install -g json-refs

--- a/specification/definitions/BaseShipment.json
+++ b/specification/definitions/BaseShipment.json
@@ -173,7 +173,7 @@
             "properties": {
               "code": {
                 "type": "string",
-                "example": "delivery-day:sunday"
+                "example": "delivery-window:sunday"
               },
               "name": {
                 "type": "string",

--- a/specification/definitions/Shipment.json
+++ b/specification/definitions/Shipment.json
@@ -187,7 +187,7 @@
             "properties": {
               "code": {
                 "type": "string",
-                "example": "delivery-day:sunday"
+                "example": "delivery-window:sunday"
               },
               "name": {
                 "type": "string",


### PR DESCRIPTION
- In our API we use options codes starting with `delivery-window`.
- Sync json-bundler image with the api-specification.