### PR TITLE
🐞 Make sure proxynet is created

### DIFF
--- a/mp.sh
+++ b/mp.sh
@@ -12,6 +12,12 @@ set -o allexport
 }
 set +o allexport
 
+if [ "$(docker network ls -q -f name=proxynet)" = "" ]; then
+  echo ""
+  echo "Creating proxynet network"
+  docker network create proxynet
+fi
+
 # run commands
 if [ $# -gt 0 ]; then
   if [ -f "mp/$1" ]; then


### PR DESCRIPTION
# Changes
Microservices require the carrier-specification through the composer.json and then the mp.sh command will be used to build the specification. The mp.sh will in turn bring the spec's docker-compose up. The spec needs proxynet, therefore we need to make sure it's always there