### PR TITLE
:whale: Use new docker compose syntax in the mp.sh script.

### DIFF
--- a/mp.sh
+++ b/mp.sh
@@ -7,7 +7,7 @@ set -o allexport
   ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
   ${ROOT_DIR}/mp/helpers/check-env
   export $(cat ${ROOT_DIR}/.env | xargs)
-  COMPOSE="docker-compose --project-name ${PROJECT_NAME}"
+  COMPOSE="docker compose --project-name ${PROJECT_NAME}"
   RUNNING=$(${COMPOSE} ps -q)
 }
 set +o allexport


### PR DESCRIPTION
## Changes
- Changed the COMPOSE variable in mp.sh to `docker compose` instead of `docker-compose`. 

## Reasoning
Docker compose V1 has been deprecated and is no longer supported as of July 2023. 
This means that newer versions of Docker start to error when using docker-compose. 
We should change all of our projects to use docker compose instead.