### PR TITLE
🐛 Remove `additionalProperties: false` from Collection schema

### DIFF
--- a/specification/paths/Collections-collection_id.json
+++ b/specification/paths/Collections-collection_id.json
@@ -39,7 +39,6 @@
                     ],
                     "properties": {
                       "attributes": {
-                        "type": "object",
                         "properties": {
                           "register": {
                             "type": "boolean",
@@ -87,10 +86,9 @@
                       "properties": {
                         "attributes": {
                           "properties": {
-                            "register": {
-                              "type": "boolean",
-                              "example": true,
-                              "description": "Indicates whether the collection should be registered at the carrier."
+                            "registered_at": {
+                              "type": "integer",
+                              "example": 1504801719
                             },
                             "tracking_code": {
                               "type": "string",

--- a/specification/schemas/Collection.json
+++ b/specification/schemas/Collection.json
@@ -7,7 +7,6 @@
       "properties": {
         "attributes": {
           "type": "object",
-          "additionalProperties": false,
           "properties": {
             "myparcelcom_collection_id": {
               "type": "string",


### PR DESCRIPTION
- Removed `additionalProperties: false` to allow for the PATCH body to add the `register` attribute.
- Changed the PATCH response to have a `registered_at` timestamp instead of the `register` boolean.