### PR TITLE
🌯 Wrap the get-pudo-by-id response in a data tag

### DIFF
--- a/specification/paths/PickupDropoffLocations-pudo_id.json
+++ b/specification/paths/PickupDropoffLocations-pudo_id.json
@@ -22,7 +22,16 @@
         "content": {
           "application/vnd.api+json": {
             "schema": {
-              "$ref": "#/components/schemas/PickupDropoffLocationResponse"
+              "type": "object",
+              "required": [
+                "data"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/components/schemas/PickupDropoffLocationResponse"
+                }
+              }
             }
           }
         }


### PR DESCRIPTION
All JSON responses with resources are supposed to be in a `data` tag.