### PR TITLE
🔖 Allow paginator output in /get-service-rates response

### DIFF
--- a/specification/paths/ServiceRates.json
+++ b/specification/paths/ServiceRates.json
@@ -78,7 +78,6 @@
               "required": [
                 "data"
               ],
-              "additionalProperties": false,
               "properties": {
                 "data": {
                   "type": "array",


### PR DESCRIPTION
The dynamic service-rate endpoints in our api-specification and carrier-specification are... well... let's call them "special".

They require a POST request, but they return multiple resources. This output is generated using our default transformer for an array of items. Therefore the response contains pagination `meta` and `links` even though there is no way to fetch page 2. This is because there will never be more than 100 service-rates for 1 specific shipment with 1 contract.

Instead of confusing our users with an optional (and useless) `meta` and `links`, I decided to allow additional properties in the response, so we can keep using our transformer to create the JSON of these ServiceRate resources.

**This allows us to use `assertJsonSchema()` in tests.**

> The reason why we return multiple rates and not just one rate: most carriers have a similar endpoint and can return multiple services. Our API POST data currently requires a service, but we could make that optional in the future.