### PR TITLE
🔥 Remove `print_sku_on_label` from shipment meta

### DIFF
--- a/specification/paths/MultiColliShipments.json
+++ b/specification/paths/MultiColliShipments.json
@@ -153,12 +153,6 @@
                         "example": "A6",
                         "default": "A6",
                         "description": "Requested size for the label of this shipment."
-                      },
-                      "print_sku_on_label": {
-                        "type": "boolean",
-                        "description": "Indicates whether or not to display SKU information table on the label.",
-                        "example": true,
-                        "default": false
                       }
                     }
                   }

--- a/specification/paths/Shipments.json
+++ b/specification/paths/Shipments.json
@@ -136,21 +136,8 @@
                         "example": "A6",
                         "default": "A6",
                         "description": "Requested size for the label of this shipment."
-                      },
-                      "print_sku_on_label": {
-                        "type": "boolean",
-                        "description": "Indicates whether or not to display SKU information table on the label.",
-                        "example": true,
-                        "default": false
                       }
                     }
-                  },
-                  "print_sku_on_label": {
-                    "type": "boolean",
-                    "description": "Deprecated, use `meta.label.print_sku_on_label` instead. Indicates whether or not to display SKU information table on the label.",
-                    "example": true,
-                    "default": false,
-                    "deprecated": true
                   }
                 }
               }


### PR DESCRIPTION
https://myparcelcombv.atlassian.net/browse/MP-6680
---
Remove `print_sku_on_label` from the shipment meta, since it's not used anymore.