### PR TITLE
🧑‍⚕️ Service rates can have options with a price

### DIFF
--- a/specification/schemas/ServiceRate.json
+++ b/specification/schemas/ServiceRate.json
@@ -65,6 +65,23 @@
                   "example": 3
                 }
               }
+            },
+            "options": {
+              "type": "array",
+              "items": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/ServiceOption"
+                  },
+                  {
+                    "properties": {
+                      "price": {
+                        "$ref": "#/components/schemas/Price"
+                      }
+                    }
+                  }
+                ]
+              }
             }
           }
         }


### PR DESCRIPTION
The service-rates response from our microservices currently consists of:
- `price` populated with the carrier's price, minus the fuel surcharge
- `fuel_surcharge`

We want them to be able to consist of:
- `price` populated with the carrier's price, minus the fuel surcharge, minus the option price(s)
- `fuel_surcharge`
- `options` which could have their own `price`