### PR TITLE
♿️ Allow `physical_properties` to have additional properties 

### DIFF
--- a/specification/schemas/BasePhysicalProperties.json
+++ b/specification/schemas/BasePhysicalProperties.json
@@ -1,6 +1,5 @@
 {
   "type": "object",
-  "additionalProperties": false,
   "properties": {
     "weight": {
       "type": "integer",


### PR DESCRIPTION
To avoid breaking on the presence of `volumetric_weight` in stub files (which all existing microservices have).