### PR TITLE
🐛 PUDO address response requires company

### DIFF
--- a/specification/schemas/PickupDropoffLocationResponse.json
+++ b/specification/schemas/PickupDropoffLocationResponse.json
@@ -17,6 +17,7 @@
           "properties": {
             "address": {
               "required": [
+                "company",
                 "street_1",
                 "city",
                 "country_code"


### PR DESCRIPTION
The api-specification is listing this as required and we need it to identify the location.
This should not be a breaking change, since all carrier locations have some kind of name.